### PR TITLE
hotfix: Convert routes to rewrites for Vercel V2 API compatibility

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -14,22 +14,22 @@
       "use": "@vercel/node"
     }
   ],
-  "routes": [
+  "rewrites": [
     {
-      "src": "/api/(.*)",
-      "dest": "/backend/src/index.ts"
+      "source": "/api/(.*)",
+      "destination": "/backend/src/index.ts"
     },
     {
-      "src": "/manifest.json",
-      "dest": "/frontend/dist/manifest.json"
+      "source": "/manifest.json",
+      "destination": "/frontend/dist/manifest.json"
     },
     {
-      "src": "/sw.js",
-      "dest": "/frontend/dist/sw.js"
+      "source": "/sw.js",
+      "destination": "/frontend/dist/sw.js"
     },
     {
-      "src": "/(.*)",
-      "dest": "/frontend/dist/index.html"
+      "source": "/(.*)",
+      "destination": "/frontend/dist/index.html"
     }
   ],
   "env": {


### PR DESCRIPTION
## Summary
- Convert routes to rewrites to resolve configuration conflict
- Update src/dest to source/destination syntax
- Fix Vercel V2 API compatibility with headers property

## Priority
High - Deployment blocker fix

## Technical Details
- routes property conflicts with headers property in Vercel V2
- rewrites is the correct approach for URL routing
- Maintains same functionality with proper syntax

Ready for immediate deployment.

🤖 Generated with [Claude Code](https://claude.ai/code)