### PR TITLE
feat: add automatic database migration on Vercel deployment

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,13 +5,14 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "tsc",
+    "build": "prisma generate --schema=../database/schema-production.prisma && prisma db push --schema=../database/schema-production.prisma && tsc",
     "start": "node dist/index.js",
     "lint": "eslint src --ext .ts",
     "test": "jest",
-    "postinstall": "prisma generate",
+    "postinstall": "prisma generate --schema=../database/schema-production.prisma",
     "db:migrate": "prisma migrate deploy",
-    "db:generate": "prisma generate"
+    "db:generate": "prisma generate",
+    "db:push": "prisma db push"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",


### PR DESCRIPTION
## Summary
- Add prisma db push to build script for automatic database migration on Vercel deployment
- Configure production schema (schema-production.prisma) usage
- Enable Prisma client generation with production schema on postinstall
- Ensure seamless database setup during deployment without manual intervention

## Changes
- Modified `backend/package.json`:
  - Updated `build` script to include Prisma client generation and database push
  - Modified `postinstall` script to use production schema
  - Added new `db:push` script for manual database pushes

## Test plan
- [x] Verify build script runs successfully with Prisma commands
- [x] Confirm postinstall generates client with correct schema
- [x] Test that database migrations apply automatically on deployment

🤖 Generated with [Claude Code](https://claude.ai/code)