### PR TITLE
Fix: Add DATABASE_URL cleaning for psql format compatibility

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -25,7 +25,21 @@ app.get('/api/health', (_req, res) => {
 app.get('/api/db-test', async (_req, res) => {
   try {
     const { PrismaClient } = await import('@prisma/client');
-    const prisma = new PrismaClient();
+    
+    // Clean DATABASE_URL if it has psql prefix
+    let cleanUrl = process.env.DATABASE_URL;
+    if (cleanUrl?.startsWith("psql '") && cleanUrl.endsWith("'")) {
+      cleanUrl = cleanUrl.slice(5, -1); // Remove "psql '" from start and "'" from end
+      console.log('🧹 Cleaned DATABASE_URL from psql format');
+    }
+    
+    const prisma = new PrismaClient({
+      datasources: {
+        db: {
+          url: cleanUrl
+        }
+      }
+    });
     
     // Check environment variables
     const databaseUrl = process.env.DATABASE_URL;


### PR DESCRIPTION
## Summary
- Auto-clean DATABASE_URL if it has psql command format
- Remove 'psql ' prefix and trailing quotes  
- Use custom datasource configuration with cleaned URL
- Ensure PostgreSQL connection compatibility

## Changes
- Enhanced `/api/db-test` endpoint with DATABASE_URL cleaning logic
- Added automatic detection of psql format (`psql 'url'`)
- Implemented URL cleaning before PrismaClient initialization
- Added console logging for debugging cleaned URLs

## Test plan
- [ ] Test with normal DATABASE_URL format
- [ ] Test with psql format DATABASE_URL (`psql 'postgresql://...'`)
- [ ] Verify database connection works after cleaning
- [ ] Check console logs show cleaning notification

🤖 Generated with [Claude Code](https://claude.ai/code)