### PR TITLE
Fix: Resolve Vercel frontend routing and static file serving

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,8 @@
       "src": "frontend/package.json",
       "use": "@vercel/static-build",
       "config": {
-        "distDir": "dist"
+        "distDir": "frontend/dist",
+        "buildCommand": "cd frontend && npm run build"
       }
     },
     {
@@ -20,16 +21,8 @@
       "destination": "/backend/src/index.ts"
     },
     {
-      "source": "/manifest.json",
-      "destination": "/frontend/dist/manifest.json"
-    },
-    {
-      "source": "/sw.js",
-      "destination": "/frontend/dist/sw.js"
-    },
-    {
       "source": "/(.*)",
-      "destination": "/frontend/dist/index.html"
+      "destination": "/index.html"
     }
   ],
   "env": {


### PR DESCRIPTION
## Summary
- Specify explicit distDir path for frontend build output
- Add explicit buildCommand for frontend compilation  
- Simplify rewrites for proper SPA routing to fix 404 errors

## Problem
- Vercel frontend deployment was failing with 404 errors on homepage
- Static file serving was not working correctly
- SPA routing was broken due to incorrect rewrites configuration

## Solution
- Updated `distDir` to explicit `frontend/dist` path
- Added explicit `buildCommand` for proper compilation
- Simplified rewrites to use `/index.html` for SPA routing
- Removed redundant static file routing rules

## Test plan
- [ ] Verify Vercel deployment builds successfully
- [ ] Test frontend homepage loads without 404 errors
- [ ] Verify SPA routing works for all frontend routes
- [ ] Confirm static files (manifest.json, sw.js) are served correctly

🤖 Generated with [Claude Code](https://claude.ai/code)