### PR TITLE
fix: simplify Vercel configuration to resolve frontend deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,28 +1,37 @@
 {
   "version": 2,
   "name": "exam-preparation-system",
-  "builds": [
-    {
-      "src": "frontend/package.json",
-      "use": "@vercel/static-build",
-      "config": {
-        "distDir": "frontend/dist",
-        "buildCommand": "cd frontend && npm run build"
-      }
-    },
-    {
-      "src": "backend/src/index.ts",
-      "use": "@vercel/node"
+  "buildCommand": "cd frontend && npm run build",
+  "outputDirectory": "frontend/dist",
+  "functions": {
+    "backend/src/index.ts": {
+      "runtime": "@vercel/node"
     }
-  ],
-  "rewrites": [
+  },
+  "routes": [
     {
-      "source": "/api/(.*)",
-      "destination": "/backend/src/index.ts"
+      "src": "/api/(.*)",
+      "dest": "/backend/src/index.ts"
     },
     {
-      "source": "/(.*)",
-      "destination": "/index.html"
+      "src": "/static/(.*)",
+      "dest": "/frontend/dist/static/$1"
+    },
+    {
+      "src": "/assets/(.*)",
+      "dest": "/frontend/dist/assets/$1"
+    },
+    {
+      "src": "/(favicon\\.ico|manifest\\.json|sw\\.js)",
+      "dest": "/frontend/dist/$1"
+    },
+    {
+      "src": "/(.*\\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot))",
+      "dest": "/frontend/dist/$1"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/frontend/dist/index.html"
     }
   ],
   "env": {


### PR DESCRIPTION
## Summary
- Replaced `builds` with `functions` for clearer serverless function setup
- Changed `rewrites` to `routes` for explicit routing control and better static file handling
- Added comprehensive static asset routing to resolve frontend 404 errors
- Improved SPA routing with proper fallback to index.html

## Changes
- **buildCommand**: Added explicit frontend build command
- **outputDirectory**: Specified frontend/dist as output directory
- **Static Asset Routes**: Added dedicated routes for `/static/*`, `/assets/*`, common files (favicon, manifest, sw.js), and all static file extensions
- **Fallback Route**: All non-API, non-static requests now properly fall back to index.html for SPA routing

## Test plan
- [ ] Verify Vercel deployment succeeds
- [ ] Test frontend routes work correctly (no 404 errors)
- [ ] Confirm static assets load properly
- [ ] Validate API endpoints remain functional
- [ ] Check Service Worker and PWA features work

🤖 Generated with [Claude Code](https://claude.ai/code)