### PR TITLE
Fix Vercel static file routing for assets and resources

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,14 @@
       "dest": "/backend/src/index.ts"
     },
     {
+      "src": "/assets/(.*)",
+      "dest": "/assets/$1"
+    },
+    {
+      "src": "/(.*\\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|json|map))",
+      "dest": "/$1"
+    },
+    {
       "src": "/(.*)",
       "dest": "/index.html"
     }


### PR DESCRIPTION
## Summary
- Fixed static file routing issues causing JavaScript files to be served as HTML
- Resolved MIME type errors preventing proper module loading
- Added dedicated routing for assets directory and static file extensions

## Problem Solved
- `/assets/index-Cg7FfSH-.js` was being served as `index.html`
- JavaScript modules failed to load due to incorrect MIME types
- `manifest.json` returned 401 errors
- Static resources were incorrectly routed through SPA fallback

## Changes Made
- Added dedicated route for `/assets/` directory
- Added routes for static file extensions (js, css, png, jpg, etc.)
- Ensured static file routing takes precedence over SPA fallback
- Proper file delivery order configuration

## Test Plan
- [ ] Verify JavaScript modules load correctly
- [ ] Check that CSS files are served with proper MIME types
- [ ] Confirm manifest.json is accessible
- [ ] Test that SPA routing still works for HTML pages
- [ ] Validate asset loading in production Vercel deployment

🤖 Generated with [Claude Code](https://claude.ai/code)