### PR TITLE
fix: Correct Cipher MCP package name to @byterover/cipher

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -26,7 +26,7 @@
     },
     "cipher": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-cipher"],
+      "args": ["-y", "@byterover/cipher"],
       "env": {}
     }
   }


### PR DESCRIPTION
## Problem
The Cipher MCP server configuration was using an incorrect package name `@modelcontextprotocol/server-cipher` which does not exist in the npm registry.

## Solution
- Updated package name to `@byterover/cipher` which is the actual working package
- This fix is required for the Cipher MCP server to load properly in Claude Code

## Testing
- Verified package exists in npm registry
- Package description matches cipher/memory functionality requirements
- Ready for Claude Code restart to test MCP server loading

## Files Changed
- `.mcp.json` - Updated cipher server package name

This is a critical fix for the MCP functionality to work properly.